### PR TITLE
WordPress 6.0 backports support for PR 2488

### DIFF
--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -132,8 +132,8 @@ function _load_remote_featured_patterns() {
  * Registers patterns from Pattern Directory provided by a theme's
  * `theme.json` file.
  *
- * @since 6.0.0
  * @access private
+ * @since 6.0.0
  */
 function _register_remote_theme_patterns() {
 	if ( ! get_theme_support( 'core-block-patterns' ) ) {
@@ -196,8 +196,8 @@ function _register_remote_theme_patterns() {
  *   - Block Types      (comma-separated values)
  *   - Inserter         (yes/no)
  *
- * @since 6.0.0
  * @access private
+ * @since 6.0.0
  */
 function _register_theme_block_patterns() {
 	$default_headers = array(

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -197,7 +197,7 @@ function _register_remote_theme_patterns() {
  *   - Inserter         (yes/no)
  *
  * @since 6.0.0
- * @access private 
+ * @access private
  */
 function _register_theme_block_patterns() {
 	$default_headers = array(

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -11,8 +11,8 @@ add_theme_support( 'core-block-patterns' );
 /**
  * Registers the core block patterns and categories.
  *
+ * @access private
  * @since 5.5.0
- * @private
  */
 function _register_core_block_patterns_and_categories() {
 	$should_register_core_patterns = get_theme_support( 'core-block-patterns' );

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -11,8 +11,8 @@ add_theme_support( 'core-block-patterns' );
 /**
  * Registers the core block patterns and categories.
  *
- * @access private
  * @since 5.5.0
+ * @access private
  */
 function _register_core_block_patterns_and_categories() {
 	$should_register_core_patterns = get_theme_support( 'core-block-patterns' );
@@ -132,8 +132,8 @@ function _load_remote_featured_patterns() {
  * Registers patterns from Pattern Directory provided by a theme's
  * `theme.json` file.
  *
- * @access private
  * @since 6.0.0
+ * @access private
  */
 function _register_remote_theme_patterns() {
 	if ( ! get_theme_support( 'core-block-patterns' ) ) {
@@ -196,8 +196,8 @@ function _register_remote_theme_patterns() {
  *   - Block Types      (comma-separated values)
  *   - Inserter         (yes/no)
  *
- * @access private
  * @since 6.0.0
+ * @access private 
  */
 function _register_theme_block_patterns() {
 	$default_headers = array(

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -939,8 +939,8 @@ function do_blocks( $content ) {
  * If do_blocks() needs to remove wpautop() from the `the_content` filter, this re-adds it afterwards,
  * for subsequent `the_content` usage.
  *
- * @access private
  * @since 5.0.0
+ * @access private 
  *
  * @param string $content The post content running through this filter.
  * @return string The unmodified content.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -788,8 +788,8 @@ function excerpt_remove_blocks( $content ) {
  * Render inner blocks from the allowed wrapper blocks
  * for generating an excerpt.
  *
- * @access private
  * @since 5.8.0
+ * @access private
  *
  * @param array $parsed_block   The parsed block.
  * @param array $allowed_blocks The list of allowed inner blocks.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -788,8 +788,8 @@ function excerpt_remove_blocks( $content ) {
  * Render inner blocks from the allowed wrapper blocks
  * for generating an excerpt.
  *
- * @since 5.8.0
  * @access private
+ * @since 5.8.0
  *
  * @param array $parsed_block   The parsed block.
  * @param array $allowed_blocks The list of allowed inner blocks.
@@ -940,7 +940,6 @@ function do_blocks( $content ) {
  * for subsequent `the_content` usage.
  *
  * @access private
- *
  * @since 5.0.0
  *
  * @param string $content The post content running through this filter.

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -337,6 +337,10 @@ function create_initial_rest_routes() {
 	$controller = new WP_REST_Pattern_Directory_Controller();
 	$controller->register_routes();
 
+	// Block Pattern Categories.
+	$controller = new WP_REST_Block_Pattern_Categories_Controller();
+	$controller->register_routes();
+
 	// Site Health.
 	$site_health = WP_Site_Health::get_instance();
 	$controller  = new WP_REST_Site_Health_Controller( $site_health );

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -337,6 +337,10 @@ function create_initial_rest_routes() {
 	$controller = new WP_REST_Pattern_Directory_Controller();
 	$controller->register_routes();
 
+	// Block Patterns.
+	$controller = new WP_REST_Block_Patterns_Controller();
+	$controller->register_routes();
+
 	// Block Pattern Categories.
 	$controller = new WP_REST_Block_Pattern_Categories_Controller();
 	$controller->register_routes();

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-pattern-categories-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-pattern-categories-controller.php
@@ -22,7 +22,7 @@ class WP_REST_Block_Pattern_Categories_Controller extends WP_REST_Controller {
 	 * @since 6.0.0
 	 */
 	public function __construct() {
-		$this->namespace = '__experimental';
+		$this->namespace = 'wp/v2';
 		$this->rest_base = 'block-patterns/categories';
 	}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
@@ -22,7 +22,7 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 	 * @since 6.0.0
 	 */
 	public function __construct() {
-		$this->namespace = '__experimental';
+		$this->namespace = 'wp/v2';
 		$this->rest_base = 'block-patterns/patterns';
 	}
 

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -277,6 +277,7 @@ require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-plugins-controller.
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-block-directory-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-edit-site-export-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php';
+require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-block-patterns-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-block-pattern-categories-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-application-passwords-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-site-health-controller.php';

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -277,6 +277,7 @@ require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-plugins-controller.
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-block-directory-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-edit-site-export-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php';
+require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-block-pattern-categories-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-application-passwords-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-site-health-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-sidebars-controller.php';

--- a/tests/phpunit/tests/rest-api/wpRestBlockPatternCategoriesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestBlockPatternCategoriesController.php
@@ -43,7 +43,7 @@ class Tests_REST_WpRestBlockPatternCategoriesController extends WP_Test_REST_Con
 	 *
 	 * @var string
 	 */
-	const REQUEST_ROUTE = '/__experimental/block-patterns/categories';
+	const REQUEST_ROUTE = '/wp/v2/block-patterns/categories';
 
 	/**
 	 * Set up class test fixtures.

--- a/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
@@ -43,7 +43,7 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 	 *
 	 * @var string
 	 */
-	const REQUEST_ROUTE = '/__experimental/block-patterns/patterns';
+	const REQUEST_ROUTE = '/wp/v2/block-patterns/patterns';
 
 	/**
 	 * Set up class test fixtures.

--- a/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
@@ -100,7 +100,6 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
 		$this->assertArrayHasKey( static::REQUEST_ROUTE, $routes );
-
 	}
 
 	public function test_get_items() {


### PR DESCRIPTION
Amendments to @hellofromtonya's backports for [PR 2488](https://github.com/WordPress/wordpress-develop/pull/2488).

Trac ticket: https://core.trac.wordpress.org/ticket/55505

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
