### PR TITLE
Fix/pr to partial hour in current time

### DIFF
--- a/tests/phpunit/tests/date/currentTime.php
+++ b/tests/phpunit/tests/date/currentTime.php
@@ -205,12 +205,12 @@ class Tests_Date_CurrentTime extends WP_UnitTestCase {
 	 */
 	public function data_partial_hour_timezones_with_timestamp() {
 		return array(
-			'+13:45' => array( 13.45 ), // New Zealand, Chatham Islands.
-			'+9:30'  => array( 9.5 ), // Australian Northern Territory.
-			'+05:30' => array( 5.5 ), // India and Sri Lanka.
-			'+05:45' => array( 5.45 ), // Nepal.
-			'-03:30' => array( -3.30 ), // Canada, Newfoundland.
-			'-09:30' => array( -9.30 ), // French Polynesia, Marquesas Islands.
+			'+12:45' => array( 12.75, 'Pacific/Chatham' ), // New Zealand, Chatham Islands.
+			'+9:30'  => array( 9.5, 'Australia/Darwin' ), // Australian Northern Territory.
+			'+05:30' => array( 5.5, 'Asia/Kolkata' ), // India and Sri Lanka.
+			'+05:45' => array( 5.75, 'Asia/Kathmandu' ), // Nepal.
+			'-03:30' => array( -3.50, 'Canada/Newfoundland' ), // Canada, Newfoundland.
+			'-09:30' => array( -9.50, 'Pacific/Marquesas' ), // French Polynesia, Marquesas Islands.
 		);
 	}
 }

--- a/tests/phpunit/tests/date/currentTime.php
+++ b/tests/phpunit/tests/date/currentTime.php
@@ -195,7 +195,7 @@ class Tests_Date_CurrentTime extends WP_UnitTestCase {
 		$expected = time() + (int) ( $partial_hour * HOUR_IN_SECONDS );
 
 		// phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
-		$this->assertSame( $expected, current_time( 'timestamp' ) );
+		$this->assertEqualsWithDelta( $expected, current_time( 'timestamp' ), 2, 'The timestamps should be equal' );
 	}
 
 	/**

--- a/tests/phpunit/tests/date/currentTime.php
+++ b/tests/phpunit/tests/date/currentTime.php
@@ -199,6 +199,38 @@ class Tests_Date_CurrentTime extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests the tests.
+	 *
+	 * This is to ensure the data provider offsets are correct.
+	 *
+	 * @ticket 57998
+	 *
+	 * @dataProvider data_partial_hour_timezones_with_timestamp
+	 *
+	 * @param float $partial_hour     Partial hour GMT offset to test.
+	 * @param string $timezone_string Timezone string to test.
+	 */
+	public function test_partial_hour_timezones_match_datetime_offset( $partial_hour, $timezone_string ) {
+		$timezone   = new DateTimeZone( $timezone_string );
+		$datetime   = new DateTime( 'now', $timezone );
+		$dst_offset = (int) $datetime->format( 'I' );
+
+		// Timezone offset in hours.
+		$offset = $timezone->getOffset( $datetime ) / HOUR_IN_SECONDS;
+
+		/*
+		 * Adjust for daylight saving time.
+		 *
+		 * DST adds an hour to the offset, the partial hour offset
+		 * is set the the standard time offset so this removes the
+		 * DST offset to avoid false negatives.
+		 */
+		$offset -= $dst_offset;
+
+		$this->assertSame( $partial_hour, $offset, 'The offset should match to timezone.' );
+	}
+
+	/**
 	 * Data provider.
 	 *
 	 * @return array


### PR DESCRIPTION
@hellofromtonya Here's a PR for a couple of suggestions to go in to your PR https://github.com/WordPress/wordpress-develop/pull/4264 

It was enough changes that inline suggestions were going to be a pain:

* Fixes the offsets for New Zealand, Chatham Islands -- it's 12.75 rather than 13.75
* For Nepal, Newfoundland and French Polynesia fixes the decimal versions of the partial hour, eg `3:30` becomes `3.5` rather than `3.3`.